### PR TITLE
fix: do not copy timers and tickers in the default implementation

### DIFF
--- a/default.go
+++ b/default.go
@@ -22,36 +22,48 @@ func (dc DefaultClock) Tick(d time.Duration) <-chan time.Time { return time.Tick
 
 // AfterFunc waits for the duration to elapse and then calls f in its own goroutine. It returns a Timer that can be used to cancel the call using its Stop method.
 func (dc DefaultClock) AfterFunc(d time.Duration, f func()) Timer {
-	return &defaultTimer{*time.AfterFunc(d, f)}
+	return &defaultTimer{t: time.AfterFunc(d, f)}
 }
 
 // NewTimer creates a new Timer that will send the current time on its channel after at least duration d.
 func (dc DefaultClock) NewTimer(d time.Duration) Timer {
-	return &defaultTimer{*time.NewTimer(d)}
+	return &defaultTimer{t: time.NewTimer(d)}
 }
 
 // NewTicker returns a new Ticker containing a channel that will send the time with a period specified by the duration argument.
 func (dc DefaultClock) NewTicker(d time.Duration) Ticker {
-	return &defaultTicker{*time.NewTicker(d)}
+	return &defaultTicker{t: time.NewTicker(d)}
 }
 
 // Since returns the time elapsed since t.
 func (dc DefaultClock) Since(t time.Time) time.Duration { return time.Since(t) }
 
-type defaultTimer struct{ time.Timer }
+type defaultTimer struct{ t *time.Timer }
 
 var _ Timer = new(defaultTimer)
 
 func (d *defaultTimer) Chan() <-chan time.Time {
-	return d.C
+	return d.t.C
 }
 
-type defaultTicker struct{ time.Ticker }
+func (d *defaultTimer) Stop() bool {
+	return d.t.Stop()
+}
+
+func (d *defaultTimer) Reset(duration time.Duration) bool {
+	return d.t.Reset(duration)
+}
+
+type defaultTicker struct{ t *time.Ticker }
 
 var _ Ticker = new(defaultTicker)
 
 func (d *defaultTicker) Chan() <-chan time.Time {
-	return d.C
+	return d.t.C
+}
+
+func (d *defaultTicker) Stop() {
+	d.t.Stop()
 }
 
 // C holds a default clock that uses time.Now as its time source. This is what you should


### PR DESCRIPTION
`DefaultClock.NewTimer()` makes a copy of a `time.Timer` instance and stores it in the newly created `defaultTimer` instance:
```
func (dc DefaultClock) NewTimer(d time.Duration) Timer {
    return &defaultTimer{*time.NewTimer(d)}
}
```

Internally, `time.NewTimer()` adds the timer instance to the current `P`'s timers heap and sets its state to `timerWaiting`.
After that, when `defaultTimer.Stop()` is called, the corresponding code in `time.Timer.Stop()` sets the timer status to `timerDeleted` for the **copied** instance, but the original instance in `P`'s heap is left intact. As a result, the timer instance is not deleted from `P`'s heap.

Instead of copying, store the original pointer to `time.Timer` in a `defaultTimer` instance. Same for `defaultTicker`.

Signed-off-by: Igor Bazhitov <igor.bazhitov@gmail.com>